### PR TITLE
Added Hydra Plus MD Italic to packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       {
         "label": "Hydra Plus MD Italic",
         "uiTheme": "vs-dark",
-        "path": "./themes/hhydra-plus-md-italic-color-theme.json"
+        "path": "./themes/hydra-plus-md-italic-color-theme.json"
       },
       {
         "label": "Hydra Plus Italic",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
         "path": "./themes/hydra-plus-md-color-theme.json"
       },
       {
+        "label": "Hydra Plus MD Italic",
+        "uiTheme": "vs-dark",
+        "path": "./themes/hhydra-plus-md-italic-color-theme.json"
+      },
+      {
         "label": "Hydra Plus Italic",
         "uiTheme": "vs-dark",
         "path": "./themes/hydra-plus-italic.json"


### PR DESCRIPTION
This is probably the slowest back and forth ever 😄 But in the last PR we forgot to add it to the actual package.json so it doesn't show up as an option in the theme selector.