### PR TITLE
Fix Notebooks not having syntax highlighting

### DIFF
--- a/themes/hydra-italic.json
+++ b/themes/hydra-italic.json
@@ -450,5 +450,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }

--- a/themes/hydra-plus-color-theme.json
+++ b/themes/hydra-plus-color-theme.json
@@ -446,5 +446,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }

--- a/themes/hydra-plus-italic.json
+++ b/themes/hydra-plus-italic.json
@@ -450,5 +450,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }

--- a/themes/hydra-plus-md-color-theme.json
+++ b/themes/hydra-plus-md-color-theme.json
@@ -446,5 +446,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }

--- a/themes/hydra-plus-md-italic-color-theme.json
+++ b/themes/hydra-plus-md-italic-color-theme.json
@@ -451,5 +451,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }

--- a/themes/hydra-plus.json
+++ b/themes/hydra-plus.json
@@ -447,5 +447,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }

--- a/themes/hydra.json
+++ b/themes/hydra.json
@@ -446,5 +446,6 @@
         "foreground": "#FF407B"
       }
     }
-  ]
+  ],
+  "semanticHighlighting": true
 }


### PR DESCRIPTION
Since a few versions ago Semantinc Highlighting needs to be enabled for the syntax highlighting to work in Notebooks.